### PR TITLE
Let the add-on publish to a broker that is not a Supervisor add-on (mqtt_host option)

### DIFF
--- a/occupancy-forecast-edge/CHANGELOG.md
+++ b/occupancy-forecast-edge/CHANGELOG.md
@@ -17,6 +17,12 @@ rejected go in the commit message instead.
 
 ### Added
 
+- The add-on can publish to a broker that is not a Supervisor add-on. Set
+  `mqtt_host` (and port, user, password, ssl) in the Configuration tab and the
+  add-on uses that broker; leave it empty and the Mosquitto add-on is used as
+  before. Until now a household on EMQX or on a Mosquitto outside Supervisor
+  could not receive the entities at all.
+
 - An AppArmor profile confining the add-on's writes to its own data directory,
   which also takes Supervisor's security rating to its cap of 8. It enforces
   rather than warns: the add-on refuses to start if the profile is wrong, which

--- a/occupancy-forecast-edge/DOCS.md
+++ b/occupancy-forecast-edge/DOCS.md
@@ -45,6 +45,14 @@ the two are comparable immediately. Set both add-ons to the same source if the
 comparison is meant to be about the code: with stable on `store` and edge on
 `influx`, a difference between them is partly a difference in training history.
 
+## A broker that is not an add-on
+
+If the MQTT integration already points at a broker outside Supervisor (EMQX,
+or Mosquitto on another machine), set `mqtt_host`, `mqtt_port`, `mqtt_user`,
+`mqtt_password` and `mqtt_ssl` in the Configuration tab. Those win over the
+Supervisor mqtt service. Leave `mqtt_host` empty and the add-on takes the
+Mosquitto add-on's details as before.
+
 ## Options, endpoints, everything else
 
 Identical to stable — see [its

--- a/occupancy-forecast-edge/config.yaml
+++ b/occupancy-forecast-edge/config.yaml
@@ -51,6 +51,11 @@ options:
   log_level: info
   source: store
   admin_users: []
+  mqtt_host: ""
+  mqtt_port: 1883
+  mqtt_user: ""
+  mqtt_password: ""
+  mqtt_ssl: false
   influx_url: ""
   influx_org: ""
   influx_bucket: homeassistant
@@ -70,3 +75,13 @@ schema:
   influx_org: str?
   influx_bucket: str?
   influx_token: password?
+  # An MQTT broker that is not a Supervisor add-on. When mqtt_host is set these
+  # five win over the Supervisor mqtt service; when it is empty the service is
+  # used as before. A broker outside Supervisor (EMQX or Mosquitto on another
+  # host) registers no service, so without these the add-on could only ever
+  # publish through the Mosquitto add-on.
+  mqtt_host: str?
+  mqtt_port: port?
+  mqtt_user: str?
+  mqtt_password: password?
+  mqtt_ssl: bool?

--- a/occupancy-forecast-edge/occupancy_forecast/config.py
+++ b/occupancy-forecast-edge/occupancy_forecast/config.py
@@ -448,8 +448,9 @@ def mqtt_settings() -> dict:
     host = os.environ.get("MQTT_HOST")
     if not host:
         raise RuntimeError(
-            "no MQTT broker: expected MQTT_HOST from Supervisor's mqtt service. "
-            "Install the Mosquitto add-on, or set it in the add-on options.")
+            "no MQTT broker: expected MQTT_HOST from the mqtt_host add-on option "
+            "or from Supervisor's mqtt service. Set mqtt_host in the add-on "
+            "options, or install the Mosquitto add-on.")
     return {
         "host": host,
         "port": int(os.environ.get("MQTT_PORT", "1883")),

--- a/occupancy-forecast-edge/run.sh
+++ b/occupancy-forecast-edge/run.sh
@@ -31,7 +31,17 @@ fi
 # `set -e` is a container that will not start over a setting nobody has touched.
 export OCCUPANCY_ADMIN_USERS="$(bashio::config 'admin_users // [] | join(",")')"
 
-if bashio::services.available 'mqtt'; then
+# An explicit broker in the options wins over the Supervisor service: a broker
+# outside Supervisor (EMQX or Mosquitto on another host) registers no service,
+# and the MQTT integration in Home Assistant is already pointed at it.
+if bashio::config.has_value 'mqtt_host'; then
+    export MQTT_HOST="$(bashio::config 'mqtt_host')"
+    export MQTT_PORT="$(bashio::config 'mqtt_port')"
+    export MQTT_USER="$(bashio::config 'mqtt_user')"
+    export MQTT_PASSWORD="$(bashio::config 'mqtt_password')"
+    export MQTT_SSL="$(bashio::config 'mqtt_ssl')"
+    bashio::log.info "MQTT broker from the add-on options: ${MQTT_HOST}:${MQTT_PORT}"
+elif bashio::services.available 'mqtt'; then
     export MQTT_HOST="$(bashio::services 'mqtt' 'host')"
     export MQTT_PORT="$(bashio::services 'mqtt' 'port')"
     export MQTT_USER="$(bashio::services 'mqtt' 'username')"
@@ -41,7 +51,7 @@ if bashio::services.available 'mqtt'; then
     export MQTT_SSL="$(bashio::services 'mqtt' 'ssl' 2>/dev/null || echo false)"
 else
     # Not fatal -- see `mqtt:want` in config.yaml.
-    bashio::log.warning "No MQTT service. Entities will not be published."
+    bashio::log.warning "No MQTT broker: no mqtt_host option and no Supervisor mqtt service. Entities will not be published."
 fi
 
 # The add-on's own name, not a literal: this file is shared by the stable and


### PR DESCRIPTION
## What

Five new add-on options on edge: `mqtt_host`, `mqtt_port`, `mqtt_user`, `mqtt_password`, `mqtt_ssl`. When `mqtt_host` is set, `run.sh` exports them and skips the Supervisor `mqtt` service. When it is empty, the service is used exactly as before, so an install that never opens the Configuration tab sees no change.

## Why

A household whose MQTT integration points at a broker outside Supervisor has no `mqtt` service for bashio to read, so the add-on could not publish at all. Here the broker is Mosquitto on another host. The `config.py` error text already said "or set it in the add-on options", and the schema had no such option. This adds the option it named.

## Measured

Installed edge from this branch on Home Assistant OS, Supervisor rating 8 with the AppArmor profile. Log on start:

```
INFO: MQTT broker from the add-on options: 192.168.1.212:1883
INFO: ready: 0 model(s), 11 person(s), source=store, log level info
INFO: alive: 1 cycles, 0/48 horizons shipping, mqtt up, listener up
```

144 entities arrived in Home Assistant through MQTT discovery from that broker. With `mqtt_host` empty the service branch runs unchanged.

## Not changed

Python reads `MQTT_HOST`, `MQTT_PORT`, `MQTT_USER`, `MQTT_PASSWORD` and `MQTT_SSL` from the environment already (`config.py` `mqtt_settings`), so only the error text changed there. Stable is untouched; this is queued in the edge changelog for the next promotion.

## Rejected

A Mosquitto add-on bridged to the external broker. It works, but it adds a second broker to a household that already has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2y86jXSsKvf9ghiwn4pxW
